### PR TITLE
Normalize group name parsing

### DIFF
--- a/app.py
+++ b/app.py
@@ -70,7 +70,13 @@ def dictionary_to_list(dictionary: Dict[str, List[str]]) -> List[str]:
     return all_values
 
 def norm_group_key(s: str) -> str:
-    return s.strip().lower()
+    """Normalize user-provided group names.
+
+    Besides trimming leading/trailing whitespace and lowercasing, collapse
+    any sequence of internal whitespace into a single space so that inputs
+    like ``"Red   Velvet"`` match stored keys such as ``"red velvet"``.
+    """
+    return " ".join(s.lower().split())
 
 def menu_keyboard() -> InlineKeyboardMarkup:
     kb = [

--- a/tests/test_norm_group_key.py
+++ b/tests/test_norm_group_key.py
@@ -1,0 +1,20 @@
+import os
+import unittest
+
+# The main application expects certain environment variables to be set at import
+# time. Provide dummy values so that importing ``app`` doesn't raise errors
+# during tests.
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy")
+os.environ.setdefault("PUBLIC_URL", "https://example.com")
+
+from app import norm_group_key
+
+
+class NormGroupKeyTest(unittest.TestCase):
+    def test_collapses_internal_whitespace(self):
+        self.assertEqual(norm_group_key("  Red   Velvet "), "red velvet")
+        self.assertEqual(norm_group_key("BLACKPINK"), "blackpink")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize whitespace when interpreting user-provided group names
- add regression test for whitespace handling

## Testing
- `python -m py_compile app.py tests/test_norm_group_key.py`
- `python -m unittest discover -s tests -p 'test*.py'`
- `pip install pyflakes` *(fails: Could not find a version that satisfies the requirement pyflakes)*

------
https://chatgpt.com/codex/tasks/task_e_68a48cda67a08326abe2f9848be8d51c