### PR TITLE
Add LLM utility to fetch top K-pop groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 .venv/
 .env
+top50_groups.json

--- a/app.py
+++ b/app.py
@@ -1,7 +1,9 @@
+import json
 import os
 import random
 from contextlib import asynccontextmanager
 from http import HTTPStatus
+from pathlib import Path
 from typing import Dict, List, Optional, Set, Iterable
 
 from fastapi import FastAPI, Request, Response
@@ -39,6 +41,19 @@ kpop_groups: Dict[str, List[str]] = {
     "baby monster": ["Ruka", "Pharita", "Chiquita", "Rami", "Asa", "Ahyeon", "Rora"],
     "kiss of life": ["Natty", "Julie", "Haneul", "Belle"],
 }
+
+AI_GROUPS_FILE = "top50_groups.json"
+
+
+def load_ai_kpop_groups(path: str = AI_GROUPS_FILE) -> Dict[str, List[str]]:
+    file = Path(path)
+    if file.exists():
+        with file.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+ai_kpop_groups: Dict[str, List[str]] = load_ai_kpop_groups()
 
 correct_grnames: Dict[str, str] = {
     "twice": "Twice",

--- a/generate_top_kpop_groups.py
+++ b/generate_top_kpop_groups.py
@@ -1,0 +1,59 @@
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+try:
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - library may be absent during tests
+    OpenAI = None  # type: ignore
+
+CACHE_FILE = "top50_groups.json"
+
+
+def generate_top_kpop_groups(cache_file: str = CACHE_FILE,
+                             model: str = "gpt-3.5-turbo") -> Dict[str, List[str]]:
+    """Generate top K-pop groups using an LLM and cache the result.
+
+    If ``cache_file`` exists, its contents are returned instead of calling
+    the API. The OpenAI API key is expected in the ``OPENAI_API_KEY``
+    environment variable.
+    """
+    path = Path(cache_file)
+    if path.exists():
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is not set")
+
+    if OpenAI is None:
+        raise RuntimeError("openai package is not installed")
+
+    client = OpenAI(api_key=api_key)
+
+    prompt = (
+        "Return a JSON object where each key is the name of a popular K-pop "
+        "girl group and the value is a list of its members. Provide exactly "
+        "50 groups."
+    )
+
+    response = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0,
+    )
+
+    text = response.choices[0].message.content  # type: ignore[attr-defined]
+    data: Dict[str, List[str]] = json.loads(text)
+
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+    return data
+
+
+if __name__ == "__main__":  # pragma: no cover
+    groups = generate_top_kpop_groups()
+    print(json.dumps(groups, ensure_ascii=False, indent=2))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-telegram-bot==20.1
 fastapi==0.110.0
 uvicorn==0.29.0
 pydantic==2.7.0
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- Implement generate_top_kpop_groups utility that queries OpenAI and caches results
- Load cached AI-generated groups at app startup into `ai_kpop_groups`
- Add OpenAI dependency

## Testing
- `python -m py_compile app.py generate_top_kpop_groups.py`


------
https://chatgpt.com/codex/tasks/task_e_68a48eb1227c832680b013d90a446c79