### PR TITLE
chore: remove obsolete menu_play_adv callback

### DIFF
--- a/app.py
+++ b/app.py
@@ -402,19 +402,6 @@ async def on_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         await launch_game(query, context, start_ai_game)
         return
 
-    if data == "menu_play_adv":
-        start_ai_game(context)
-        member = next_question(context)
-        if member is None:
-            await query.edit_message_text(finish_text(context), reply_markup=back_keyboard())
-            return
-        await query.edit_message_text(
-            f"К какой группе относится: {member}?\n\nНапиши название группы.",
-            reply_markup=in_game_keyboard(),
-            parse_mode="Markdown",
-        )
-        return
-
     # --- Показать все группы
     if data == "menu_show_all":
         lines: List[str] = []


### PR DESCRIPTION
## Summary
- remove unused `menu_play_adv` callback handling in `on_callback`

## Testing
- `PYTHONPATH=. TELEGRAM_BOT_TOKEN=1 PUBLIC_URL=1 pytest -q`
- `rg menu_play_adv -n`

------
https://chatgpt.com/codex/tasks/task_e_68a49e2225a08326bd28ae136f367b2f