### PR TITLE
feat: improve AI game guidance and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Kpop Challenge Bot
+
+## Режим ИИ
+
+Для использования режима игры с ИИ:
+
+1. Установите библиотеку `openai`:
+   ```bash
+   pip install openai
+   ```
+2. Установите переменную окружения `OPENAI_API_KEY` со своим ключом OpenAI.
+3. Сгенерируйте список групп:
+   ```bash
+   OPENAI_API_KEY=... python generate_top_kpop_groups.py
+   ```
+4. Поместите полученный `top50_groups.json` в ту же папку, что и `app.py`.
+
+После этого в меню бота станет доступен пункт **AI игра**.

--- a/app.py
+++ b/app.py
@@ -245,7 +245,12 @@ async def launch_game(
     ok = starter(context)
     if not ok:
         await query.edit_message_text(
-            "AI-список групп недоступен. Попробуйте позже.",
+            (
+                "AI-список групп недоступен.\n\n"
+                "Создайте файл top50_groups.json, запустив generate_top_kpop_groups.py "
+                "после установки переменной окружения OPENAI_API_KEY, и разместите его "
+                "рядом с app.py."
+            ),
             reply_markup=back_keyboard(),
         )
         return


### PR DESCRIPTION
## Summary
- clarify how to obtain AI group list when file is missing
- document AI game setup steps

## Testing
- `OPENAI_API_KEY=dummy python generate_top_kpop_groups.py`
- `python - <<'PY'
import os; os.environ['TELEGRAM_BOT_TOKEN']='x'; os.environ['PUBLIC_URL']='https://example.com'; from types import SimpleNamespace; import app; ctx=SimpleNamespace(user_data={}); app.start_ai_game(ctx); print(app.next_question(ctx))
PY`
- `PYTHONPATH=. TELEGRAM_BOT_TOKEN=x PUBLIC_URL=https://example.com pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a49e2c81cc8326976b078721ed6437