### PR TITLE
Add AI game tests and streamline dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ python-telegram-bot==20.1
 fastapi==0.110.0
 uvicorn==0.29.0
 pydantic==2.7.0
-openai>=1.0.0
+pytest>=8.0.0

--- a/tests/test_ai_game.py
+++ b/tests/test_ai_game.py
@@ -1,0 +1,34 @@
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+# Avoid runtime errors when importing app
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy")
+os.environ.setdefault("PUBLIC_URL", "https://example.com")
+
+import app
+
+DUMMY_DATA = {
+    "group_a": ["a1", "a2", "a3", "a4"],
+    "group_b": ["b1", "b2", "b3", "b4"],
+    "group_c": ["c1", "c2", "c3", "c4"],
+}
+
+
+def test_load_ai_kpop_groups(tmp_path):
+    data_file = tmp_path / "top50_groups.json"
+    data_file.write_text(json.dumps(DUMMY_DATA), encoding="utf-8")
+    loaded = app.load_ai_kpop_groups(data_file)
+    assert loaded == DUMMY_DATA
+
+
+def test_start_ai_game(monkeypatch):
+    ctx = SimpleNamespace(user_data={})
+    monkeypatch.setattr(app, "ai_kpop_groups", DUMMY_DATA)
+    assert app.start_ai_game(ctx)
+    assert ctx.user_data["mode"] == "ai_game"
+    assert len(ctx.user_data["game"]["members"]) == 10

--- a/tests/test_norm_group_key.py
+++ b/tests/test_norm_group_key.py
@@ -1,9 +1,12 @@
 import os
+import sys
+from pathlib import Path
 import unittest
 
 # The main application expects certain environment variables to be set at import
-# time. Provide dummy values so that importing ``app`` doesn't raise errors
-# during tests.
+# time. Provide dummy values and ensure project root is on sys.path.
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy")
 os.environ.setdefault("PUBLIC_URL", "https://example.com")
 


### PR DESCRIPTION
## Summary
- add tests for loading AI K-pop groups from JSON and starting AI game
- include pytest in requirements and drop OpenAI dependency to run tests offline
- ensure existing tests can import project modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a49e5a25388326975dd3ba0548a119