### PR TITLE
Expand group sources and name matching

### DIFF
--- a/tests/test_ai_game.py
+++ b/tests/test_ai_game.py
@@ -29,6 +29,7 @@ def test_load_ai_kpop_groups(tmp_path):
 def test_start_ai_game(monkeypatch):
     ctx = SimpleNamespace(user_data={})
     monkeypatch.setattr(app, "ai_kpop_groups", DUMMY_DATA)
+    monkeypatch.setattr(app, "ai_correct_grnames", {k: k for k in DUMMY_DATA})
     assert app.start_ai_game(ctx)
     assert ctx.user_data["mode"] == "ai_game"
     assert len(ctx.user_data["game"]["members"]) == 10

--- a/tests/test_find_member_ai.py
+++ b/tests/test_find_member_ai.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+import asyncio
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy")
+os.environ.setdefault("PUBLIC_URL", "https://example.com")
+
+import app
+
+
+def test_find_member_from_ai_group():
+    messages = []
+
+    async def fake_reply_text(text, **kwargs):
+        messages.append(text)
+
+    update = SimpleNamespace(
+        message=SimpleNamespace(text="Jin", reply_text=fake_reply_text)
+    )
+    ctx = SimpleNamespace(user_data={"mode": "find"})
+    asyncio.run(app.on_text(update, ctx))
+    assert any("BTS" in m for m in messages)

--- a/tests/test_pretty_map_spaces.py
+++ b/tests/test_pretty_map_spaces.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy")
+os.environ.setdefault("PUBLIC_URL", "https://example.com")
+
+import app
+
+
+def test_pretty_map_accepts_spaceless_names():
+    groups = {"red velvet": ["A", "B"]}
+    names_map = {"red velvet": "Red Velvet"}
+    mapping = app.build_pretty_map(groups, names_map)
+    assert mapping["redvelvet"] == "red velvet"


### PR DESCRIPTION
## Summary
- Allow training and member search across both built-in and AI-generated groups
- Accept group answers with or without internal spaces in both game modes
- Add tests covering space-insensitive names and AI-group member search

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a55c960b3483269ff4404ae976a1d0