### PR TITLE
Align Dropbox root default across scripts

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,7 +48,7 @@ kpop_groups: Dict[str, List[str]] = {
 AI_GROUPS_FILE = "top50_groups.json"
 PHOTO_GAME_QUESTIONS = 20
 DROPBOX_PHOTO_FILE = "dropbox_photos.json"
-DROPBOX_ROOT = os.environ.get("DROPBOX_ROOT", "")
+DROPBOX_ROOT = os.environ.get("DROPBOX_ROOT", "./dropbox_sync")
 
 
 def _load_dropbox_map(path: str = DROPBOX_PHOTO_FILE) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- default `DROPBOX_ROOT` to `./dropbox_sync` in app code so it matches the sync script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72bad861c8326a1d977ba50e68653