### PR TITLE
Add setuptools requirement for deployment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ uvicorn==0.29.0
 pydantic==2.7.0
 pytest>=8.0.0
 dropbox==11.36.0
+setuptools>=65


### PR DESCRIPTION
## Summary
- add setuptools>=65 to requirements to ensure package installation

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-telegram-bot==20.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a73b5601a083268a8519bcf55ba94c