### PR TITLE
Fix catalog navigation and group filtering

### DIFF
--- a/app.py
+++ b/app.py
@@ -494,7 +494,7 @@ def catalog_nav_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         [
             [InlineKeyboardButton("▶️ Следующее фото", callback_data="catalog_next")],
-            [InlineKeyboardButton("📁 Каталог", callback_data="menu_catalog")],
+            [InlineKeyboardButton("📁 Обратно в меню каталога", callback_data="menu_catalog")],
             [InlineKeyboardButton("🏠 В главное меню", callback_data="menu_back")],
         ]
     )
@@ -505,6 +505,12 @@ def catalog_groups_keyboard() -> InlineKeyboardMarkup:
     buttons: List[List[InlineKeyboardButton]] = []
     row: List[InlineKeyboardButton] = []
     for key in correct_grnames.keys():
+        members = ALL_GROUPS.get(key, [])
+        has_photo = any(
+            re.sub(r"[-_\s]", "", m.lower()) in DROPBOX_PHOTOS for m in members
+        )
+        if not has_photo:
+            continue
         title = correct_grnames[key]
         row.append(InlineKeyboardButton(title, callback_data=f"{CB_CATALOG_PICK}{key}"))
         if len(row) == 2:
@@ -710,7 +716,11 @@ async def on_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     # --- Назад в меню
     if data == "menu_back":
         reset_state(context)
-        await query.edit_message_text("Меню:", reply_markup=menu_keyboard())
+        try:
+            await query.edit_message_reply_markup(reply_markup=None)
+        except Exception:
+            pass
+        await query.message.reply_text("Меню:", reply_markup=menu_keyboard())
         return
 
     # --- Игра «Угадай группу»
@@ -736,7 +746,12 @@ async def on_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 
     # --- Каталог фото
     if data == "menu_catalog":
-        await query.edit_message_text(
+        reset_state(context)
+        try:
+            await query.edit_message_reply_markup(reply_markup=None)
+        except Exception:
+            pass
+        await query.message.reply_text(
             "Каталог фото:", reply_markup=catalog_menu_keyboard()
         )
         return

--- a/tests/test_catalog_groups_keyboard.py
+++ b/tests/test_catalog_groups_keyboard.py
@@ -1,0 +1,12 @@
+import app
+
+
+def test_catalog_groups_keyboard_filters(monkeypatch):
+    groups = {"g1": ["a"], "g2": ["b"]}
+    monkeypatch.setattr(app, "ALL_GROUPS", groups)
+    monkeypatch.setattr(app, "correct_grnames", {"g1": "G1", "g2": "G2"})
+    monkeypatch.setattr(app, "DROPBOX_PHOTOS", {"a": "/x"})
+
+    kb = app.catalog_groups_keyboard()
+    texts = [btn.text for row in kb.inline_keyboard[:-1] for btn in row]
+    assert texts == ["G1"]


### PR DESCRIPTION
## Summary
- fix navigation buttons when viewing photos and rename catalog button
- hide groups without photos in catalog and add test
- ensure 'stop game' works by handling callbacks from photos

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-telegram-bot==20.1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68a879bdfa748326b4d3c364686bfc3e