### PR TITLE
Use all Dropbox images for photo modes

### DIFF
--- a/tests/test_catalog_groups_keyboard.py
+++ b/tests/test_catalog_groups_keyboard.py
@@ -5,7 +5,7 @@ def test_catalog_groups_keyboard_filters(monkeypatch):
     groups = {"g1": ["a"], "g2": ["b"]}
     monkeypatch.setattr(app, "ALL_GROUPS", groups)
     monkeypatch.setattr(app, "correct_grnames", {"g1": "G1", "g2": "G2"})
-    monkeypatch.setattr(app, "DROPBOX_PHOTOS", {"a": "/x"})
+    monkeypatch.setattr(app, "DROPBOX_PHOTOS", {"a": ["/x"]})
 
     kb = app.catalog_groups_keyboard()
     texts = [btn.text for row in kb.inline_keyboard[:-1] for btn in row]

--- a/tests/test_photo_game_structure.py
+++ b/tests/test_photo_game_structure.py
@@ -10,16 +10,42 @@ def test_start_photo_game_dropbox(monkeypatch):
     # Подготовим тестовые данные: у двух айдолов есть изображения, у одного нет
     groups = {"g": ["idol one", "idol two", "idol three"]}
     monkeypatch.setattr(app, "ALL_GROUPS", groups)
-    monkeypatch.setattr(app, "PHOTO_GAME_QUESTIONS", 2)
+    monkeypatch.setattr(app, "PHOTO_GAME_QUESTIONS", 3)
 
     def fake_fetch(name):
-        return b"img" if name in {"idol one", "idol two"} else None
+        if name == "idol one":
+            return [b"img1", b"img2"]
+        if name == "idol two":
+            return [b"img3"]
+        return []
 
-    monkeypatch.setattr(app, "fetch_dropbox_image", fake_fetch)
+    monkeypatch.setattr(app, "fetch_dropbox_images", fake_fetch)
 
     ctx = DummyContext()
     assert app.start_photo_game(ctx)
     items = ctx.user_data["game"]["items"]
-    assert len(items) == 2
-    names = {item["name"] for item in items}
-    assert names == {"idol one", "idol two"}
+    assert len(items) == 3
+    names = [item["name"] for item in items]
+    assert names.count("idol one") == 2
+    assert names.count("idol two") == 1
+
+
+def test_photo_game_picks_unique_images(monkeypatch):
+    # подготовим 30 уникальных фото и убедимся, что берётся ровно 20 без повторов
+    groups = {"g": [f"idol {i}" for i in range(30)]}
+    monkeypatch.setattr(app, "ALL_GROUPS", groups)
+    monkeypatch.setattr(app, "PHOTO_GAME_QUESTIONS", 20)
+
+    def fake_fetch(name):
+        idx = int(name.split()[1])
+        # каждая участница имеет одно уникальное изображение
+        return [bytes([idx])]
+
+    monkeypatch.setattr(app, "fetch_dropbox_images", fake_fetch)
+
+    ctx = DummyContext()
+    assert app.start_photo_game(ctx)
+    items = ctx.user_data["game"]["items"]
+    assert len(items) == 20
+    images = [item["image"] for item in items]
+    assert len(set(images)) == 20


### PR DESCRIPTION
## Summary
- Scan Dropbox and track all images per member instead of only first
- Use every available member photo in photo game and catalog modes
- Add lightweight fallbacks for FastAPI and Telegram modules
- Sample exactly 20 unique photos per round in photo guessing game

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87f1c36c083269fbacf371f202524