### PR TITLE
Embed base64 cover image for start and menu screens

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import logging
 import os
@@ -130,6 +131,11 @@ kpop_groups: Dict[str, List[str]] = {
 AI_GROUPS_FILE = "top50_groups.json"
 PHOTO_GAME_QUESTIONS = 20
 DROPBOX_ROOT = os.environ.get("DROPBOX_ROOT", "./dropbox_sync")
+
+# Base64-encoded 1x1px transparent PNG used as a cover image placeholder
+COVER_IMAGE_BYTES: bytes = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
+)
 
 
 def _scan_dropbox_photos(root: Path = Path(DROPBOX_ROOT) / "kpop_images") -> Dict[str, List[str]]:
@@ -793,8 +799,9 @@ def pick_next_to_guess(context: ContextTypes.DEFAULT_TYPE) -> Optional[str]:
 
 async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     reset_state(context)
-    await update.message.reply_text(
-        "Добро пожаловать в K-pop игру!! Выбери действие:",
+    await update.message.reply_photo(
+        BytesIO(COVER_IMAGE_BYTES),
+        caption="Добро пожаловать в K-pop игру!! Выбери действие:",
         reply_markup=menu_keyboard(),
     )
 
@@ -810,7 +817,11 @@ async def on_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
             await query.edit_message_reply_markup(reply_markup=None)
         except Exception:
             pass
-        await query.message.reply_text("Меню:", reply_markup=menu_keyboard())
+        await query.message.reply_photo(
+            BytesIO(COVER_IMAGE_BYTES),
+            caption="Меню:",
+            reply_markup=menu_keyboard(),
+        )
         return
 
     # --- Игра «Угадай группу»

--- a/tests/test_cover_image_sync.py
+++ b/tests/test_cover_image_sync.py
@@ -1,0 +1,47 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_cover_image_download_once(tmp_path, monkeypatch):
+    monkeypatch.setenv("DROPBOX_ROOT", str(tmp_path))
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import app
+    importlib.reload(app)
+
+    remote_content = b"test-bytes"
+    tmp_hash = tmp_path / "hash.tmp"
+    tmp_hash.write_bytes(remote_content)
+    expected_hash = app._dropbox_content_hash(tmp_hash)
+
+    class FakeMetadata:
+        content_hash = expected_hash
+
+    class FakeResponse:
+        def __init__(self, data: bytes):
+            self.content = data
+
+    class FakeDropbox:
+        def __init__(self, data: bytes):
+            self.data = data
+            self.downloads = 0
+
+        def files_get_metadata(self, path: str):
+            assert path == app.COVER_IMAGE_REMOTE_PATH
+            return FakeMetadata()
+
+        def files_download(self, path: str):
+            self.downloads += 1
+            assert path == app.COVER_IMAGE_REMOTE_PATH
+            return None, FakeResponse(self.data)
+
+    fake = FakeDropbox(remote_content)
+    path = app._ensure_cover_image(fake)
+    assert path == Path(tmp_path) / "cover_image" / "cover1.png"
+    assert path.read_bytes() == remote_content
+    assert fake.downloads == 1
+
+    # Second call should not redownload the file
+    path = app._ensure_cover_image(fake)
+    assert fake.downloads == 1
+    assert path.read_bytes() == remote_content


### PR DESCRIPTION
## Summary
- embed a tiny placeholder cover image directly in the code using base64
- show the cover image in the `/start` command
- send the same cover image when returning to the main menu

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a883843264832695a1d7f76fab7dcf