### PR TITLE
Shuffle group photos in catalog

### DIFF
--- a/app.py
+++ b/app.py
@@ -698,12 +698,13 @@ def catalog_groups_keyboard() -> InlineKeyboardMarkup:
 def build_catalog_for_group(
     group_key: str, groups: Dict[str, List[str]] = ALL_GROUPS
 ) -> List[Dict[str, bytes | str]]:
-    """Собирает фотографии участников выбранной группы."""
+    """Собирает фотографии участников выбранной группы в случайном порядке."""
     items: List[Dict[str, bytes | str]] = []
     for name in groups.get(group_key, []):
         imgs = fetch_dropbox_images(name)
         for img in imgs:
             items.append({"image": img, "name": name, "group": group_key})
+    random.shuffle(items)
     return items
 
 

--- a/tests/test_catalog_functions.py
+++ b/tests/test_catalog_functions.py
@@ -14,10 +14,16 @@ def test_build_catalog_for_group(monkeypatch):
 
     monkeypatch.setattr(app, "fetch_dropbox_images", fake_fetch)
 
+    # Ensure items are shuffled by reversing the list
+    def fake_shuffle(lst):
+        lst.reverse()
+
+    monkeypatch.setattr(app.random, "shuffle", fake_shuffle)
+
     items = app.build_catalog_for_group("g1", app.ALL_GROUPS)
     assert items == [
-        {"image": b"img1", "name": "a", "group": "g1"},
         {"image": b"img2", "name": "a", "group": "g1"},
+        {"image": b"img1", "name": "a", "group": "g1"},
     ]
 
 


### PR DESCRIPTION
## Summary
- Randomize order of group photo catalog entries
- Adjust catalog tests to account for shuffling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87e67f06483268e11d1ab6181d10b