### PR TITLE
Prevent duplicate photo uploads

### DIFF
--- a/tests/test_next_member_filename.py
+++ b/tests/test_next_member_filename.py
@@ -1,0 +1,16 @@
+import app
+from pathlib import Path
+
+
+def test_next_member_filename_no_regex_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(app, "DROPBOX_ROOT", tmp_path)
+    member = "idol+"  # contains regex special char
+    group_key = "g"
+    suffix = ".jpg"
+    member_dir = Path(tmp_path) / "kpop_images" / group_key / member
+    member_dir.mkdir(parents=True)
+    # create existing file to trigger regex evaluation
+    (member_dir / f"{member}__01{suffix}").touch()
+
+    filename = app._next_member_filename(group_key, member, suffix)
+    assert filename == f"{member}__02{suffix}"

--- a/tests/test_save_user_photo_duplicates.py
+++ b/tests/test_save_user_photo_duplicates.py
@@ -1,0 +1,17 @@
+import app
+import pytest
+from pathlib import Path
+
+
+def test_save_user_photo_prevents_duplicates(tmp_path, monkeypatch):
+    monkeypatch.setattr(app, "DROPBOX_ROOT", tmp_path)
+    monkeypatch.setattr(app, "DROPBOX_PHOTOS", {})
+    data = b"imgdata"
+    assert app.save_user_photo("g", "idol", data, ".jpg")
+    member_dir = Path(tmp_path) / "kpop_images" / "g" / "idol"
+    assert len(list(member_dir.glob("*"))) == 1
+    with pytest.raises(FileExistsError):
+        app.save_user_photo("g", "idol", data, ".jpg")
+    # Ensure file not duplicated
+    assert len(list(member_dir.glob("*"))) == 1
+    assert len(app.DROPBOX_PHOTOS.get("idol", [])) == 1


### PR DESCRIPTION
## Summary
- compute Dropbox content hash for incoming photo bytes
- reject saving identical photos and notify user
- escape member names when scanning existing files to avoid regex errors
- add regression tests for duplicate uploads and filename handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8cca2e61c83269349ab1dfb024fb8