### PR TITLE
Add photo catalog link after upload

### DIFF
--- a/app.py
+++ b/app.py
@@ -417,6 +417,16 @@ def menu_keyboard() -> InlineKeyboardMarkup:
 def back_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup([[InlineKeyboardButton("⬅️ Назад в меню", callback_data="menu_back")]])
 
+
+def upload_success_keyboard() -> InlineKeyboardMarkup:
+    """Клавиатура после успешной загрузки фото."""
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("📁 В каталог фото", callback_data="menu_catalog")],
+            [InlineKeyboardButton("⬅️ Назад в меню", callback_data="menu_back")],
+        ]
+    )
+
 def in_game_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup([[InlineKeyboardButton("🏁 Прервать игру", callback_data="menu_back")]])
 
@@ -1509,7 +1519,7 @@ async def on_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 if update.effective_user:
                     register_user_upload(update.effective_user.id)
                 await update.message.reply_text(
-                    "Фото успешно загружено!", reply_markup=back_keyboard()
+                    "Фото успешно загружено!", reply_markup=upload_success_keyboard()
                 )
             else:
                 await update.message.reply_text(

--- a/tests/test_upload_success_keyboard.py
+++ b/tests/test_upload_success_keyboard.py
@@ -1,0 +1,10 @@
+import app
+
+
+def test_upload_success_keyboard_buttons():
+    kb = app.upload_success_keyboard()
+    assert len(kb.inline_keyboard) == 2
+    assert kb.inline_keyboard[0][0].text == "📁 В каталог фото"
+    assert kb.inline_keyboard[0][0].callback_data == "menu_catalog"
+    assert kb.inline_keyboard[1][0].text == "⬅️ Назад в меню"
+    assert kb.inline_keyboard[1][0].callback_data == "menu_back"


### PR DESCRIPTION
## Summary
- Add `upload_success_keyboard` offering navigation to catalog or main menu after photo upload
- Update upload workflow to use new keyboard
- Add tests for `upload_success_keyboard`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a93c2ebda88326b4ea77bff9b63b72