### PR TITLE
Enable photo catalog access after photo upload

### DIFF
--- a/app.py
+++ b/app.py
@@ -418,15 +418,6 @@ def back_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup([[InlineKeyboardButton("⬅️ Назад в меню", callback_data="menu_back")]])
 
 
-def upload_success_keyboard() -> InlineKeyboardMarkup:
-    """Клавиатура после успешной загрузки фото."""
-    return InlineKeyboardMarkup(
-        [
-            [InlineKeyboardButton("📁 В каталог фото", callback_data="menu_catalog")],
-            [InlineKeyboardButton("⬅️ Назад в меню", callback_data="menu_back")],
-        ]
-    )
-
 def in_game_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup([[InlineKeyboardButton("🏁 Прервать игру", callback_data="menu_back")]])
 
@@ -437,8 +428,10 @@ CB_UPLOAD_MORE = "upload_more"       # добавить ещё фото
 
 
 def upload_success_keyboard() -> InlineKeyboardMarkup:
+    """Клавиатура после успешной загрузки фото."""
     return InlineKeyboardMarkup([
         [InlineKeyboardButton("Добавить ещё фото", callback_data=CB_UPLOAD_MORE)],
+        [InlineKeyboardButton("📁 В каталог фото", callback_data="menu_catalog")],
         [InlineKeyboardButton("⬅️ Назад в меню", callback_data="menu_back")],
     ])
 

--- a/tests/test_upload_success_keyboard.py
+++ b/tests/test_upload_success_keyboard.py
@@ -3,8 +3,10 @@ import app
 
 def test_upload_success_keyboard_buttons():
     kb = app.upload_success_keyboard()
-    assert len(kb.inline_keyboard) == 2
-    assert kb.inline_keyboard[0][0].text == "📁 В каталог фото"
-    assert kb.inline_keyboard[0][0].callback_data == "menu_catalog"
-    assert kb.inline_keyboard[1][0].text == "⬅️ Назад в меню"
-    assert kb.inline_keyboard[1][0].callback_data == "menu_back"
+    assert len(kb.inline_keyboard) == 3
+    assert kb.inline_keyboard[0][0].text == "Добавить ещё фото"
+    assert kb.inline_keyboard[0][0].callback_data == app.CB_UPLOAD_MORE
+    assert kb.inline_keyboard[1][0].text == "📁 В каталог фото"
+    assert kb.inline_keyboard[1][0].callback_data == "menu_catalog"
+    assert kb.inline_keyboard[2][0].text == "⬅️ Назад в меню"
+    assert kb.inline_keyboard[2][0].callback_data == "menu_back"


### PR DESCRIPTION
## Summary
- Show "Go to photo catalog" button after successful photo uploads alongside add-more and back options
- Update tests for new upload success keyboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9502c479883268af52d6a00a5cde9