### PR TITLE
feat: extend photo upload success menu

### DIFF
--- a/app.py
+++ b/app.py
@@ -425,12 +425,14 @@ def in_game_keyboard() -> InlineKeyboardMarkup:
 CB_UPLOAD_GROUP = "upload_group:"    # выбор группы для загрузки
 CB_UPLOAD_MEMBER = "upload_member:"  # выбор участника для загрузки
 CB_UPLOAD_MORE = "upload_more"       # добавить ещё фото
+CB_UPLOAD_OTHER = "upload_other"     # добавить фото для другого айдола
 
 
 def upload_success_keyboard() -> InlineKeyboardMarkup:
     """Клавиатура после успешной загрузки фото."""
     return InlineKeyboardMarkup([
-        [InlineKeyboardButton("Добавить ещё фото", callback_data=CB_UPLOAD_MORE)],
+        [InlineKeyboardButton("Добавить ещё фото для этого айдола", callback_data=CB_UPLOAD_MORE)],
+        [InlineKeyboardButton("Добавить для других айдолов", callback_data=CB_UPLOAD_OTHER)],
         [InlineKeyboardButton("📁 В каталог фото", callback_data="menu_catalog")],
         [InlineKeyboardButton("⬅️ Назад в меню", callback_data="menu_back")],
     ])
@@ -1239,6 +1241,15 @@ async def on_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         await query.message.reply_text(
             f"Отправьте фото для {member} (до 8 МБ)",
             reply_markup=back_keyboard(),
+        )
+        return
+
+    if data == CB_UPLOAD_OTHER:
+        context.user_data["mode"] = "upload_group"
+        context.user_data.pop("upload_group", None)
+        context.user_data.pop("upload_member", None)
+        await query.message.reply_text(
+            "Выберите группу:", reply_markup=upload_groups_keyboard()
         )
         return
 

--- a/tests/test_upload_success_keyboard.py
+++ b/tests/test_upload_success_keyboard.py
@@ -3,10 +3,12 @@ import app
 
 def test_upload_success_keyboard_buttons():
     kb = app.upload_success_keyboard()
-    assert len(kb.inline_keyboard) == 3
-    assert kb.inline_keyboard[0][0].text == "Добавить ещё фото"
+    assert len(kb.inline_keyboard) == 4
+    assert kb.inline_keyboard[0][0].text == "Добавить ещё фото для этого айдола"
     assert kb.inline_keyboard[0][0].callback_data == app.CB_UPLOAD_MORE
-    assert kb.inline_keyboard[1][0].text == "📁 В каталог фото"
-    assert kb.inline_keyboard[1][0].callback_data == "menu_catalog"
-    assert kb.inline_keyboard[2][0].text == "⬅️ Назад в меню"
-    assert kb.inline_keyboard[2][0].callback_data == "menu_back"
+    assert kb.inline_keyboard[1][0].text == "Добавить для других айдолов"
+    assert kb.inline_keyboard[1][0].callback_data == app.CB_UPLOAD_OTHER
+    assert kb.inline_keyboard[2][0].text == "📁 В каталог фото"
+    assert kb.inline_keyboard[2][0].callback_data == "menu_catalog"
+    assert kb.inline_keyboard[3][0].text == "⬅️ Назад в меню"
+    assert kb.inline_keyboard[3][0].callback_data == "menu_back"


### PR DESCRIPTION
## Summary
- clarify photo upload continuation button and add option to upload for another idol
- handle new callback to restart upload flow
- adjust tests for extended menu

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9849e496c832683bfe0001ded3848