### PR TITLE
Add K-pop true/false quiz backed by API

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,12 +4,22 @@ import logging
 import os
 import random
 import re
+import time
 from contextlib import asynccontextmanager
 from datetime import date
 from http import HTTPStatus
 from io import BytesIO
 from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple
+
+try:  # pragma: no cover - requests might be missing during tests
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - used only when requests missing
+    class _RequestsModule:
+        def get(self, *args, **kwargs):  # pragma: no cover - network disabled
+            raise RuntimeError("requests library not installed")
+
+    requests = _RequestsModule()  # type: ignore
 
 try:
     from fastapi import FastAPI, Request, Response
@@ -269,6 +279,49 @@ def load_quiz_questions(path: str = QUIZ_FILE) -> List[Dict[str, str]]:
 
 QUIZ_POOL: List[Dict[str, str]] = load_quiz_questions()
 
+# Endpoint providing random K-pop true/false facts.
+# The API at kpop-facts-api.vercel.app aggregates data from Wikipedia and
+# official fan databases and documents a recommended limit of one request per
+# second.  ``fetch_tf_statement`` implements that limit and provides basic error
+# handling so the bot can operate offline using mocked responses in tests.
+TF_API_URL = "https://kpop-facts-api.vercel.app/random?type=tf"
+TF_RATE_LIMIT_SECONDS = 1.0
+_tf_last_call = 0.0
+
+
+def fetch_tf_statement() -> Tuple[str, bool]:
+    """Return a random K-pop statement and whether it is true.
+
+    The data is retrieved from ``TF_API_URL`` which returns JSON in the form
+    ``{"statement": "text", "is_true": true}``.
+    ``RuntimeError`` is raised when the request fails or the data is
+    malformed.  Calls are rate limited according to ``TF_RATE_LIMIT_SECONDS``.
+    """
+
+    global _tf_last_call
+
+    # Enforce simple rate limiting recommended by the data provider.
+    elapsed = time.time() - _tf_last_call
+    if elapsed < TF_RATE_LIMIT_SECONDS:
+        time.sleep(TF_RATE_LIMIT_SECONDS - elapsed)
+
+    try:
+        resp = requests.get(TF_API_URL, timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        logging.error("TF API request failed: %s", exc)
+        raise RuntimeError("tf_api_request_failed") from exc
+
+    statement = data.get("statement") or data.get("fact")
+    truth = data.get("is_true") if "is_true" in data else data.get("truth")
+    if not statement or truth is None:
+        logging.error("TF API returned invalid data: %s", data)
+        raise RuntimeError("tf_api_invalid_data")
+
+    _tf_last_call = time.time()
+    return statement, bool(truth)
+
 
 def _scan_dropbox_photos(root: Path = Path(DROPBOX_ROOT) / "kpop_images") -> Dict[str, List[str]]:
     """Обходит локальную синхронизацию Dropbox и строит карту
@@ -427,6 +480,7 @@ def menu_keyboard() -> InlineKeyboardMarkup:
         ("7. Режим обучения", "menu_learn"),
         ("8. Каталог фото", "menu_catalog"),
         ("9. [адм.] Добавить фото", "menu_upload"),
+        ("10. Правда или ложь", "menu_true_false"),
     ]
     kb = [[InlineKeyboardButton(text, callback_data=cb)] for text, cb in entries]
     return InlineKeyboardMarkup(kb)
@@ -737,6 +791,25 @@ def start_quiz(context: ContextTypes.DEFAULT_TYPE) -> bool:
         "score": 0,
         "current": None,
         "total": sample_size,
+    }
+    return True
+
+
+def start_true_false_quiz(context: ContextTypes.DEFAULT_TYPE) -> bool:
+    """Запускает квиз «Правда или ложь» с использованием внешнего API."""
+
+    try:
+        statement, truth = fetch_tf_statement()
+    except Exception:
+        # При любых проблемах с API возвращаем False, чтобы вызывающий код мог
+        # отреагировать и сообщить пользователю об ошибке.
+        return False
+
+    context.user_data["mode"] = "true_false"
+    context.user_data["true_false"] = {
+        "statement": statement,
+        "answer": truth,
+        "score": 0,
     }
     return True
 
@@ -1215,6 +1288,24 @@ async def on_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
             await ask_quiz_question(query.message, q, prefix="Вопрос 1:\n")
         return
 
+    # --- Игра "Правда или ложь"
+    if data == "menu_true_false":
+        try:
+            await query.edit_message_reply_markup(reply_markup=None)
+        except Exception:
+            pass
+        ok = start_true_false_quiz(context)
+        if not ok:
+            await query.message.reply_text(
+                "Факты недоступны.", reply_markup=back_keyboard()
+            )
+            return
+        stmt = context.user_data.get("true_false", {}).get("statement", "")
+        await query.message.reply_text(
+            f"Правда или ложь?\n\n{stmt}", reply_markup=in_game_keyboard()
+        )
+        return
+
     # --- Каталог фото
     if data == "menu_catalog":
         reset_state(context)
@@ -1471,6 +1562,52 @@ async def on_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 break
         else:
             await update.message.reply_text("Такой участник не найден", reply_markup=back_keyboard())
+        return
+
+    # --- Квиз "Правда или ложь"
+    if mode == "true_false":
+        g = context.user_data.get("true_false", {})
+        statement = g.get("statement")
+        answer = g.get("answer")
+        # Если по какой-то причине нет текущего утверждения, попробуем получить новое
+        if statement is None or answer is None:
+            ok = start_true_false_quiz(context)
+            if not ok:
+                await update.message.reply_text(
+                    "Факты недоступны.", reply_markup=back_keyboard()
+                )
+                reset_state(context)
+                return
+            g = context.user_data.get("true_false", {})
+            statement = g.get("statement")
+            answer = g.get("answer")
+
+        normalized = text.lower()
+        is_true = normalized in ("true", "правда", "да", "yes", "t", "y", "верно")
+        is_false = normalized in ("false", "ложь", "нет", "no", "f", "n", "неверно")
+        if not is_true and not is_false:
+            await update.message.reply_text(
+                "Ответь 'правда' или 'ложь'", reply_markup=in_game_keyboard()
+            )
+            return
+        is_correct = (is_true and answer) or (is_false and not answer)
+        feedback = "Верно!" if is_correct else "Неверно!"
+        if is_correct:
+            g["score"] = g.get("score", 0) + 1
+        try:
+            new_stmt, new_answer = fetch_tf_statement()
+            g.update({"statement": new_stmt, "answer": new_answer})
+            context.user_data["true_false"] = g
+            await update.message.reply_text(
+                f"{feedback}\nСчёт: {g.get('score', 0)}\n\n{new_stmt}",
+                reply_markup=in_game_keyboard(),
+            )
+        except Exception:
+            await update.message.reply_text(
+                f"{feedback}\nСчёт: {g.get('score', 0)}\n\nБольше фактов недоступно.",
+                reply_markup=back_keyboard(),
+            )
+            reset_state(context)
         return
 
     # --- Квиз на знание k-pop

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic==2.7.0
 pytest>=8.0.0
 dropbox==11.36.0
 setuptools>=65
+requests>=2.31.0

--- a/tests/test_true_false_quiz.py
+++ b/tests/test_true_false_quiz.py
@@ -1,0 +1,89 @@
+import pytest
+import app
+import asyncio
+from types import SimpleNamespace
+
+
+class DummyContext:
+    def __init__(self):
+        self.user_data = {}
+
+class DummyResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status = status
+    def raise_for_status(self):
+        if self.status != 200:
+            raise Exception("bad status")
+    def json(self):
+        return self._payload
+
+
+def test_fetch_tf_statement_success(monkeypatch):
+    def fake_get(url, timeout=5):
+        assert url == app.TF_API_URL
+        return DummyResponse({"statement": "Lisa is in Blackpink", "is_true": True})
+    monkeypatch.setattr(app.requests, "get", fake_get)
+    stmt, truth = app.fetch_tf_statement()
+    assert stmt == "Lisa is in Blackpink"
+    assert truth is True
+
+
+def test_fetch_tf_statement_rate_limit(monkeypatch):
+    times = iter([10.0, 10.0, 10.3, 10.3])
+    monkeypatch.setattr(app, "_tf_last_call", 0.0)
+    monkeypatch.setattr(app.time, "time", lambda: next(times))
+    slept = {}
+    monkeypatch.setattr(app.time, "sleep", lambda t: slept.setdefault("duration", t))
+    monkeypatch.setattr(
+        app.requests,
+        "get",
+        lambda url, timeout=5: DummyResponse({"statement": "A", "is_true": True}),
+    )
+    app.fetch_tf_statement()
+    app.fetch_tf_statement()
+    assert slept["duration"] == pytest.approx(app.TF_RATE_LIMIT_SECONDS - 0.3)
+
+
+def test_start_true_false_quiz_success(monkeypatch):
+    ctx = DummyContext()
+    monkeypatch.setattr(app, "fetch_tf_statement", lambda: ("Fact", True))
+    assert app.start_true_false_quiz(ctx)
+    assert ctx.user_data["true_false"]["statement"] == "Fact"
+    assert ctx.user_data["true_false"]["answer"] is True
+
+
+def test_start_true_false_quiz_failure(monkeypatch):
+    ctx = DummyContext()
+    def boom():
+        raise RuntimeError("boom")
+    monkeypatch.setattr(app, "fetch_tf_statement", boom)
+    assert app.start_true_false_quiz(ctx) is False
+    assert "true_false" not in ctx.user_data
+
+
+def test_menu_keyboard_contains_true_false():
+    kb = app.menu_keyboard()
+    callbacks = [btn.callback_data for row in kb.inline_keyboard for btn in row]
+    assert "menu_true_false" in callbacks
+
+
+def test_true_false_flow(monkeypatch):
+    facts = iter([
+        ("First", True),
+        ("Second", False),
+    ])
+    monkeypatch.setattr(app, "fetch_tf_statement", lambda: next(facts))
+    ctx = DummyContext()
+    assert app.start_true_false_quiz(ctx)
+
+    messages = []
+
+    class DummyMessage:
+        async def reply_text(self, text, **kwargs):
+            messages.append(text)
+
+    update = SimpleNamespace(message=SimpleNamespace(text="правда", reply_text=DummyMessage().reply_text))
+    asyncio.run(app.on_text(update, ctx))
+    assert any("Верно" in m for m in messages)
+    assert ctx.user_data["true_false"]["statement"] == "Second"


### PR DESCRIPTION
## Summary
- fetch random K-pop true/false facts from an external API with rate limiting and error handling
- integrate a new `start_true_false_quiz` that uses the API instead of hardcoded questions and add the quiz to the main menu
- test the new API-backed quiz using mocked responses, including menu and answer flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9afc6c5488326aea5c780e40d4e5a